### PR TITLE
Limit the cert cache size

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+### 1.1.0 (June 20, 2013)
+
+* Rework Cert logic - [@sbeckeriv]
+
 ### 1.0.1 (May 17, 2013)
 
 * Gem housekeeping, based on [advice by dblock](http://code.dblock.org/your-first-ruby-gem)

--- a/lib/heroic/sns/message.rb
+++ b/lib/heroic/sns/message.rb
@@ -1,19 +1,78 @@
 require 'json'
 require 'base64'
+require "singleton"
 
 module Heroic
   module SNS
-
     MAXIMUM_ALLOWED_AGE = 3600 # reject messages older than one hour
 
-    CERTIFICATE_CACHE = Hash.new do |cache, cert_url|
-      begin
-        cert_data = open(cert_url)
-        cache[cert_url] = OpenSSL::X509::Certificate.new(cert_data.read)
-      rescue OpenURI::HTTPError => e
-        raise Error.new("unable to retrieve signing certificate: #{e.message}; URL: #{cert_url}")
-      rescue OpenSSL::X509::CertificateError => e
-        raise Error.new("unable to parse signing certificate: #{e.message}; URL: #{cert_url}")
+    class CertificateCache 
+      MAXIMUM_ALLOWED_CERTIFICATES = 50 #Then clear
+      include Singleton
+
+      class CertificateStore
+        def initialize
+          @certificates = {}
+        end
+
+        def get_certificate(cert_url)
+          @certificates[cert_url] || load_certificate(cert_url)
+        end
+
+        def load(hash)
+          @certificates = hash
+        end
+
+        def clear_certificates
+          @certificates.clear
+        end
+
+        def certificate_count
+          @certificates.size
+        end
+
+        private
+
+        def load_certificate(cert_url)
+          begin
+            cert_data = open(cert_url)
+            @certificates[cert_url] = OpenSSL::X509::Certificate.new(cert_data.read)
+          rescue OpenSSL::X509::CertificateError => e
+            raise SNS::Error.new("unable to parse signing certificate: #{e.message}; URL: #{cert_url}")
+          rescue => e
+            raise SNS::Error.new("unable to retrieve signing certificate: #{e.message}; URL: #{cert_url}")
+          end
+        end
+      end
+
+      def initialize 
+        @cert_store = CertificateStore.new
+        @lock = Mutex.new
+      end
+
+      def get_certificate(cert_url)
+        @lock.synchronize do
+          clear_certificates_unlocked
+          @cert_store.get_certificate(cert_url)
+        end
+      end
+
+      def load(hash)
+        @lock.synchronize do
+          @cert_store.load(hash)
+        end
+      end
+
+      def clear_certificates
+        @lock.synchronize do
+          clear_certificates_unlocked
+        end
+      end
+      private 
+      def clear_certificates_unlocked
+          if(@cert_store.certificate_count > MAXIMUM_ALLOWED_CERTIFICATES)
+            @cert_store.clear_certificates
+          end
       end
     end
 
@@ -104,7 +163,7 @@ module Heroic
       # See: http://docs.aws.amazon.com/sns/latest/gsg/SendMessageToHttp.verify.signature.html
       def verify!
         age = Time.now - timestamp
-        raise Errow.new("timestamp is in the future", self) if age < 0
+        raise Error.new("timestamp is in the future", self) if age < 0
         raise Error.new("timestamp is too old", self) if age > MAXIMUM_ALLOWED_AGE
         if signature_version != '1'
           raise Error.new("unknown signature version: #{signature_version}", self)
@@ -113,7 +172,7 @@ module Heroic
           raise Error.new("signing certificate is not from amazonaws.com", self)
         end
         text = string_to_sign # will warn of invalid Type
-        cert = CERTIFICATE_CACHE[signing_cert_url]
+        cert = CertificateCache.instance.get_certificate(signing_cert_url)
         digest = OpenSSL::Digest::SHA1.new
         unless cert.public_key.verify(digest, signature, text)
           raise Error.new("message signature is invalid", self)

--- a/lib/heroic/sns/version.rb
+++ b/lib/heroic/sns/version.rb
@@ -1,5 +1,5 @@
 module Heroic
   module SNS
-    VERSION = '1.0.1'
+    VERSION = '1.1.0'
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,7 +5,7 @@
 
 module Heroic
   module SNS
-
+=begin
     TEST_CERT_URL = 'https://sns.test.amazonaws.com/self-signed.pem'
     TEST_CERT_KEY = OpenSSL::PKey::RSA.new(File.read('test/fixtures/sns.key'))
 
@@ -15,7 +15,7 @@ module Heroic
       cert_data = File.read('test/fixtures/sns.crt')
       OpenSSL::X509::Certificate.new(cert_data)
     end
-
+=end
     class Message
 
       def update_timestamp!(t = Time.now)

--- a/test/test_certificate_cache.rb
+++ b/test/test_certificate_cache.rb
@@ -1,0 +1,27 @@
+require 'test/unit'
+require 'heroic/sns'
+require 'helper'
+class CertificateCacheTest < Test::Unit::TestCase
+
+  def test_bad_url_raises
+    assert_raises Heroic::SNS::Error do  
+      Heroic::SNS::CertificateCache.instance.get_certificate("httpbad:://google")
+    end
+  end
+
+  def test_store_is_cleared
+    bad_hash={}
+    (Heroic::SNS::CertificateCache::MAXIMUM_ALLOWED_CERTIFICATES + 1).times{|i| bad_hash[i]=i}
+    Heroic::SNS::CertificateCache.instance.load(bad_hash)
+    assert_raises Heroic::SNS::Error do  
+      Heroic::SNS::CertificateCache.instance.get_certificate(33)
+    end
+  end
+  def test_store_is_not_cleared_early
+
+    bad_hash={}
+    (Heroic::SNS::CertificateCache::MAXIMUM_ALLOWED_CERTIFICATES ).times{|i| bad_hash[i]=i}
+    Heroic::SNS::CertificateCache.instance.load(bad_hash)
+    assert_equal 4, Heroic::SNS::CertificateCache.instance.get_certificate(4)
+  end
+end


### PR DESCRIPTION
Cache should use an LRU hash instead of wiping out all the data, however, I write this with a hard limit to keep it simple. I created test but could not get the original tests to work. Might be better to use mock the getting of the cert. 

Also  Errow.new was bad.

Thoughts?
